### PR TITLE
fix(continuum): make auto-save die with its psmux server

### DIFF
--- a/psmux-continuum/plugin.conf
+++ b/psmux-continuum/plugin.conf
@@ -5,14 +5,12 @@
 # =============================================================================
 # Default: auto-save every 15 minutes, auto-restore off, auto-boot off.
 #
-# NOTE: The auto_save.ps1 script runs a persistent loop (sleeping between
-# saves). run-shell executes it asynchronously so it won't block psmux.
-# client-attached fires on every attach, but auto_save.ps1 holds a named
-# mutex so only a single auto-save loop runs per user session. Repeat
-# attaches start a script that exits immediately (no process accumulation).
+# NOTE: see auto_save.ps1's header for the loop's lifecycle (single-instance
+# handling, and what happens if the server dies mid-save). run-shell executes it
+# asynchronously so it won't block psmux.
 
 # Start auto-save background loop on client attach (every 15 minutes)
-set-hook -g client-attached 'run-shell "pwsh -NoProfile -File \"~/.psmux/plugins/psmux-continuum/scripts/auto_save.ps1\" -IntervalMinutes 15"'
+set-hook -g client-attached 'run-shell "pwsh -NoProfile -File \"~/.psmux/plugins/psmux-continuum/scripts/auto_save.ps1\" -Interval 00:15:00"'
 
 # --- Auto-restore (opt-in via @continuum-restore 'on') ---
 # The hook is always registered; auto_restore.ps1 reads @continuum-restore

--- a/psmux-continuum/scripts/auto_save.ps1
+++ b/psmux-continuum/scripts/auto_save.ps1
@@ -1,18 +1,78 @@
 #!/usr/bin/env pwsh
-# psmux-continuum: Background auto-save loop
+# psmux-continuum: auto-save loop that lives and dies with its psmux server.
+#
+# Lifecycle: resolve the server (see Get-ServerProcess; exit if none), take a
+# per-server-pid mutex (one loop per server, so a repeat client-attached fire is a
+# no-op), then block-and-save until the server exits. If the server dies WHILE a
+# save runs, the loop finishes that save before the next block reaps - so a mid-save
+# death delays the reap by up to one save.
 param(
-    [int]$IntervalMinutes = 15
+    # Save cadence (e.g. 00:15:00).
+    [TimeSpan]$Interval = [TimeSpan]::FromMinutes(15),
+    # The psmux server process to watch; $null = auto-detect (see Get-ServerProcess).
+    [Nullable[int]]$ServerPid = $null
 )
 
 $ErrorActionPreference = 'Continue'
 
-# --- Single-instance guard -------------------------------------------------
-# The client-attached hook in plugin.conf fires on EVERY attach, so without a
-# guard a new auto-save loop would spawn on each attach and never exit, leaving
-# dozens of pwsh processes running (issue #24). A named mutex keeps a single
-# auto-save loop per user session; later instances exit immediately. If the
-# previous owner was killed the mutex is abandoned and we reclaim it.
-$mutex = New-Object System.Threading.Mutex($false, 'Local\psmux-continuum-autosave')
+function Get-PsmuxBin {
+    foreach ($n in @('psmux', 'pmux', 'tmux')) {
+        $b = Get-Command $n -ErrorAction SilentlyContinue
+        if ($b) { return $b.Source }
+    }
+    return 'psmux'
+}
+
+$PSMUX = Get-PsmuxBin
+
+# Resolve the psmux server process this loop belongs to, so the wait loop below
+# can exit the instant it dies. Three tiers, most to least reliable:
+#   1. $ServerPid, when a caller passes it - authoritative.
+#   2. Our parent process: run-shell spawns this script directly as a child of the
+#      server, so the parent IS the server - no psmux call.
+#   3. `display-message -p '#{pid}'`, only when the parent isn't a psmux process.
+function Get-ServerProcess {
+    if ($null -ne $ServerPid) { return Get-Process -Id $ServerPid -ErrorAction SilentlyContinue }
+    $parentId = (Get-CimInstance Win32_Process -Filter "ProcessId = $PID" -ErrorAction SilentlyContinue).ParentProcessId
+    if ($parentId) {
+        $parent = Get-Process -Id $parentId -ErrorAction SilentlyContinue
+        if ($parent -and $parent.ProcessName -in @('psmux', 'pmux', 'tmux')) { return $parent }
+    }
+    try {
+        $queried = [int]((& $PSMUX display-message -p '#{pid}' 2>&1 | Out-String).Trim())
+        if ($queried -gt 0) { return Get-Process -Id $queried -ErrorAction SilentlyContinue }
+    } catch {}
+    return $null
+}
+
+$server = Get-ServerProcess
+if (-not $server) {
+    # Can't identify our server: refuse to run rather than spin a loop that could
+    # outlive it and orphan.
+    Write-Host "psmux-continuum: could not resolve the psmux server process; auto-save not started." -ForegroundColor Yellow
+    exit 0
+}
+
+# Force the OS process handle open now, while the pid is known live, so the wait
+# loop below tracks THIS process object - not whatever might later reuse the pid.
+try { $null = $server.SafeHandle } catch { }
+
+# Find the resurrect save script.
+$saveScript = Join-Path $PSScriptRoot '..\..\psmux-resurrect\scripts\save.ps1'
+if (-not (Test-Path $saveScript)) {
+    $saveScript = Join-Path $env:USERPROFILE '.psmux\plugins\psmux-resurrect\scripts\save.ps1'
+}
+if (-not (Test-Path $saveScript)) {
+    Write-Host "psmux-continuum: psmux-resurrect not found. Install it first." -ForegroundColor Red
+    exit 1
+}
+
+$cadenceMs = [int]$Interval.TotalMilliseconds
+
+# Single-instance guard (issue #24), keyed to this server's pid so a new server's
+# loop is never blocked by a previous server's. An abandoned mutex (loop
+# force-killed) is reclaimed.
+$mutex = New-Object System.Threading.Mutex($false, "Local\psmux-continuum-autosave-$($server.Id)")
 try {
     $haveLock = $mutex.WaitOne(0)
 } catch [System.Threading.AbandonedMutexException] {
@@ -22,41 +82,17 @@ if (-not $haveLock) {
     exit 0
 }
 
-function Get-PsmuxBin {
-    foreach ($n in @('psmux','pmux','tmux')) {
-        $b = Get-Command $n -ErrorAction SilentlyContinue
-        if ($b) { return $b.Source }
-    }
-    return 'psmux'
-}
-
-$PSMUX = Get-PsmuxBin
-
-# Find the resurrect save script
-$saveScript = Join-Path $PSScriptRoot '..\..\psmux-resurrect\scripts\save.ps1'
-if (-not (Test-Path $saveScript)) {
-    $saveScript = Join-Path $env:USERPROFILE '.psmux\plugins\psmux-resurrect\scripts\save.ps1'
-}
-
-if (-not (Test-Path $saveScript)) {
-    Write-Host "psmux-continuum: psmux-resurrect not found. Install it first." -ForegroundColor Red
-    exit 1
-}
-
-$IntervalSeconds = $IntervalMinutes * 60
-
 try {
     while ($true) {
-        Start-Sleep -Seconds $IntervalSeconds
-
-        # Check if psmux server is still running
-        $sessions = & $PSMUX ls 2>&1 | Out-String
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host "psmux-continuum: Server not running, stopping auto-save." -ForegroundColor Yellow
+        # Block on the server for one interval: returns the instant it exits (reap)
+        # or on timeout (time to save). Throws only if the handle goes bad; treat
+        # that as the server being gone.
+        try {
+            if ($server.WaitForExit($cadenceMs)) { break }
+        } catch {
             break
         }
 
-        # Run the save
         & pwsh -NoProfile -File $saveScript
         Write-Host "psmux-continuum: Auto-saved at $(Get-Date -Format 'HH:mm:ss')" -ForegroundColor DarkGray
     }


### PR DESCRIPTION
## What

Rewrites psmux-continuum's `auto_save.ps1` so the auto-save loop **lives and dies with its psmux server** instead of outliving it.

## Why

The old loop slept a fixed interval and only noticed the server was gone on its next wake via `psmux ls`, so a `kill-server` or restart orphaned it until the next tick. Its fixed-name mutex then blocked the new server's loop from starting until that orphan was killed (issue #24 territory).

## How

- The loop blocks on the server process itself: one `WaitForExit` doubles as the save cadence (its timeout) and the death signal (it returns the instant the server exits), so the loop reaps with its server.
- The single-instance mutex is keyed to the server pid, so a new server's loop is never blocked by a dying one.
- The server is resolved via the loop's parent process (`run-shell` spawns this script as a child of the server), with the process handle forced open up front to avoid a pid-reuse race.
- Cadence is a `[TimeSpan] -Interval` (e.g. `00:15:00`).
- If the server dies while a save runs, the sync save finishes first (against a dead server its psmux calls return empty), then the next block reaps, so the loop outlives its server by at most one save.

## Depends on

Without the psmux-side fix **psmux/psmux#456**, the hidden `__warm__` pre-spawn server also fires `client-attached` and spawns a second auto-save loop (a double-save).

## Testing

End-to-end against isolated psmux servers (with the #456 binary):

- Cold-spawn session -> exactly 1 loop; saves fire on cadence; loop reaps ~150 ms after the server dies, no orphan.
- Warm-stay (unclaimed) -> 0 loops.
- Warm-claim (promoted) -> exactly 1 loop; reaps with its server.
- Repeat `client-attached` on the same server -> mutex keeps a single loop.