### PR TITLE
[Agent] Restore missing windows into existing resurrect sessions

### DIFF
--- a/psmux-resurrect/README.md
+++ b/psmux-resurrect/README.md
@@ -31,7 +31,7 @@ set -g @plugin 'psmux-plugins/psmux-resurrect'
 
 ## What Gets Restored
 
-- All sessions (idempotent by default: existing sessions are skipped, see `@resurrect-overwrite` below to change this)
+- All sessions (idempotent by default: existing sessions are reused and only missing saved windows are restored)
 - Windows with correct names
 - Panes in correct working directories
 - Exact layout geometry via `select-layout` replay
@@ -63,10 +63,10 @@ set -g @resurrect-processes ':all:'
 # Use tilde for fuzzy matching (restore if command contains the string)
 set -g @resurrect-processes '"~rails server" "~npm start"'
 
-# Overwrite sessions that are already running instead of skipping them.
-# Default is off, matching the current skip-if-running behavior. When 'on',
-# a running session with a name that matches the save is killed and
-# recreated from the save instead of being left alone.
+# Overwrite sessions that are already running instead of reusing them.
+# Default is off: matching live windows are preserved and missing saved
+# windows are restored into the existing session. When 'on', the running
+# session is killed and fully recreated from the save.
 set -g @resurrect-overwrite 'on'
 ```
 
@@ -93,11 +93,10 @@ On completion the status briefly shows a summary, then clears:
 psmux-resurrect: restored 7 sessions, 23 windows in 3.1s
 ```
 
-Skipped sessions (already running) and failures are reported in the summary
-too:
+Reused sessions and failures are reported in the summary too:
 
 ```
-psmux-resurrect: restored 0/12, skipped 12 (already running)
+psmux-resurrect: restored 12 sessions, 7 windows in 1.8s (4 existing sessions reused)
 ```
 
 With `@resurrect-overwrite 'on'`, sessions that were killed and recreated are

--- a/psmux-resurrect/plugin.conf
+++ b/psmux-resurrect/plugin.conf
@@ -12,7 +12,7 @@
 #   set -g @resurrect-processes 'ssh python node'         # extra processes to restore
 #   set -g @resurrect-processes 'false'                   # disable process restore
 #   set -g @resurrect-processes ':all:'                   # restore all (dangerous)
-#   set -g @resurrect-overwrite 'on'                      # kill + recreate existing sessions on restore (default off = skip)
+#   set -g @resurrect-overwrite 'on'                      # kill + recreate existing sessions (default off = restore missing windows)
 #   set -g @resurrect-save 'S'                            # custom save key
 #   set -g @resurrect-restore 'R'                         # custom restore key
 

--- a/psmux-resurrect/psmux-resurrect.ps1
+++ b/psmux-resurrect/psmux-resurrect.ps1
@@ -24,7 +24,7 @@
 #   set -g @resurrect-processes 'ssh python node'
 #   set -g @resurrect-processes 'false'           # disable process restore
 #   set -g @resurrect-processes ':all:'           # restore all (dangerous)
-#   set -g @resurrect-overwrite 'on'              # kill + recreate existing sessions on restore (default off = skip)
+#   set -g @resurrect-overwrite 'on'              # kill + recreate existing sessions (default off = restore missing windows)
 # =============================================================================
 
 $ErrorActionPreference = 'Continue'

--- a/psmux-resurrect/scripts/restore.ps1
+++ b/psmux-resurrect/scripts/restore.ps1
@@ -133,9 +133,9 @@ try {
         return $false
     }
 
-    # Check @resurrect-overwrite option: default off, preserves the existing
-    # skip-if-running behavior. When 'on', a session with the same saved name
-    # is killed and recreated from the save instead of being left alone.
+    # Check @resurrect-overwrite option. By default, existing sessions are
+    # preserved and reconciled by restoring only their missing saved windows.
+    # When 'on', the whole session is killed and recreated from the save.
     $overwriteExisting = $false
     try {
         $overwriteOpt = (& $PSMUX show-options -gv '@resurrect-overwrite' 2>&1 | Out-String).Trim()
@@ -146,7 +146,7 @@ try {
     $startTime = Get-Date
     $restoredCount = 0
     $overwrittenCount = 0
-    $skipped = @()
+    $reusedCount = 0
     $failed = @()
     $totalWindows = 0
 
@@ -160,6 +160,48 @@ try {
         return $null
     }
 
+    function Restore-WindowPanes {
+        param($win, [string]$initialPaneId)
+
+        if (-not $initialPaneId) { return }
+
+        $paneIds = @($initialPaneId)
+        if ($win.panes.Count -gt 1) {
+            for ($p = 1; $p -lt $win.panes.Count; $p++) {
+                $pDir = if ($win.panes[$p].directory) { $win.panes[$p].directory } else { $env:USERPROFILE }
+                $paneIds += Get-PaneId (& $PSMUX split-window -t $initialPaneId -c $pDir -P -F '#{pane_id}' 2>&1)
+            }
+        }
+
+        if ($win.layout) {
+            & $PSMUX select-layout -t $initialPaneId $win.layout 2>&1 | Out-Null
+        }
+
+        $activePaneId = $null
+        for ($ti = 0; $ti -lt $win.panes.Count; $ti++) {
+            $paneId = $paneIds[$ti]
+            if (-not $paneId) { continue }
+            $pane = $win.panes[$ti]
+            if ($pane.title) {
+                & $PSMUX select-pane -t $paneId -T $pane.title 2>&1 | Out-Null
+            }
+            if ($pane.active -eq $true) { $activePaneId = $paneId }
+            if ($restoreProcesses -and $pane.command -and (Should-RestoreProcess $pane.command)) {
+                & $PSMUX send-keys -t $paneId $pane.command Enter 2>&1 | Out-Null
+                Start-Sleep -Milliseconds 200
+            }
+        }
+        if ($activePaneId) {
+            & $PSMUX select-pane -t $activePaneId 2>&1 | Out-Null
+        }
+
+        if ($win.zoomed -eq $true -and $win.panes.Count -gt 1 -and $activePaneId) {
+            & $PSMUX resize-pane -Z -t $activePaneId 2>&1 | Out-Null
+        }
+
+        return $activePaneId
+    }
+
     for ($si = 0; $si -lt $totalSessions; $si++) {
         $session = $env_data.sessions[$si]
         $sessionName = $session.name
@@ -170,8 +212,66 @@ try {
         $null = & $PSMUX has-session -t $sessionName 2>&1
         if ($LASTEXITCODE -eq 0) {
             if (-not $overwriteExisting) {
-                Write-Host "  Session '$sessionName' already exists, skipping" -ForegroundColor Yellow
-                $skipped += $sessionName
+                Write-Host "  Session '$sessionName' already exists, restoring missing windows" -ForegroundColor Yellow
+
+                $existingWindowTargets = @{}
+                $windowLines = & $PSMUX list-windows -t $sessionName -F '#{window_index}|#{window_name}' 2>&1
+                foreach ($line in @($windowLines)) {
+                    $parts = "$line".Trim() -split '\|', 2
+                    if ($parts.Count -eq 2 -and $parts[1]) {
+                        $existingWindowTargets[$parts[1]] = "${sessionName}:$($parts[0])"
+                    }
+                }
+
+                $windowPaneIds = @()
+                $windowActivePaneIds = @()
+                $addedWindows = 0
+                foreach ($win in @($session.windows)) {
+                    if ($win.name -and $existingWindowTargets.ContainsKey($win.name)) {
+                        $windowPaneIds += $null
+                        $windowActivePaneIds += $null
+                        continue
+                    }
+
+                    $winDir = if ($win.panes -and $win.panes[0].directory) {
+                        $win.panes[0].directory
+                    } else {
+                        $env:USERPROFILE
+                    }
+                    $newWinArgs = @('-t', $sessionName, '-c', $winDir)
+                    if ($win.name) {
+                        $newWinArgs = @('-t', $sessionName, '-n', $win.name, '-c', $winDir)
+                    }
+                    $winPaneId = Get-PaneId (& $PSMUX new-window @newWinArgs -P -F '#{pane_id}' 2>&1)
+                    $windowPaneIds += $winPaneId
+                    $windowActivePaneIds += (Restore-WindowPanes -win $win -initialPaneId $winPaneId)
+                    if ($winPaneId) {
+                        $addedWindows++
+                        if ($win.name) { $existingWindowTargets[$win.name] = $winPaneId }
+                    }
+                }
+
+                $savedWindows = @($session.windows)
+                for ($i = 0; $i -lt $savedWindows.Count; $i++) {
+                    if ($savedWindows[$i].active -eq $true) {
+                        $activeWindowTarget = $windowPaneIds[$i]
+                        if (-not $activeWindowTarget -and $savedWindows[$i].name) {
+                            $activeWindowTarget = $existingWindowTargets[$savedWindows[$i].name]
+                        }
+                        if ($activeWindowTarget) {
+                            & $PSMUX select-window -t $activeWindowTarget 2>&1 | Out-Null
+                            if ($windowActivePaneIds[$i]) {
+                                & $PSMUX select-pane -t $windowActivePaneIds[$i] 2>&1 | Out-Null
+                            }
+                        }
+                        break
+                    }
+                }
+
+                $restoredCount++
+                $reusedCount++
+                $totalWindows += $addedWindows
+                Write-Host "  Reconciled session: $sessionName ($addedWindows missing windows restored)" -ForegroundColor Green
                 continue
             }
 
@@ -218,64 +318,6 @@ try {
             Write-Host "  Failed to create session '$sessionName'" -ForegroundColor Red
             $failed += $sessionName
             continue
-        }
-
-        # Restore a window's panes.
-        function Restore-WindowPanes {
-            param($win, [string]$initialPaneId)
-
-            # Without the initial pane's id we can't target this window, so skip it.
-            if (-not $initialPaneId) { return }
-
-            # Ordered pane ids for this window: initial pane, then one per split,
-            # in creation order (1:1 with $win.panes). Split entries may be $null.
-            $paneIds = @($initialPaneId)
-            if ($win.panes.Count -gt 1) {
-                for ($p = 1; $p -lt $win.panes.Count; $p++) {
-                    $pDir = if ($win.panes[$p].directory) { $win.panes[$p].directory } else { $env:USERPROFILE }
-                    $paneIds += Get-PaneId (& $PSMUX split-window -t $initialPaneId -c $pDir -P -F '#{pane_id}' 2>&1)
-                }
-            }
-
-            # Replay the saved layout so split orientations and sizes match the original
-            if ($win.layout) {
-                & $PSMUX select-layout -t $initialPaneId $win.layout 2>&1 | Out-Null
-            }
-
-            # Select the active pane last: select-pane -T and send-keys, used
-            # below, both move the active pane.
-            $activePaneId = $null
-            for ($ti = 0; $ti -lt $win.panes.Count; $ti++) {
-                $paneId = $paneIds[$ti]
-                if (-not $paneId) { continue }
-                $pane = $win.panes[$ti]
-                if ($pane.title) {
-                    & $PSMUX select-pane -t $paneId -T $pane.title 2>&1 | Out-Null
-                }
-                if ($pane.active -eq $true) { $activePaneId = $paneId }
-                if ($restoreProcesses -and $pane.command -and (Should-RestoreProcess $pane.command)) {
-                    & $PSMUX send-keys -t $paneId $pane.command Enter 2>&1 | Out-Null
-                    Start-Sleep -Milliseconds 200
-                }
-            }
-            if ($activePaneId) {
-                & $PSMUX select-pane -t $activePaneId 2>&1 | Out-Null
-            }
-
-            # Re-zoom the active pane (the pane that was zoomed).
-            if ($win.zoomed -eq $true -and $win.panes.Count -gt 1 -and $activePaneId) {
-                & $PSMUX resize-pane -Z -t $activePaneId 2>&1 | Out-Null
-            }
-
-            # Report this window's real active pane id back to the caller: the
-            # end-of-session "select active window" step below targets a window by
-            # one of its pane ids, and psmux's target resolution for select-window
-            # also re-activates that specific pane as a side effect (confirmed
-            # against the real binary: `select-window -t <pane-id>` makes that exact
-            # pane active). Without this, selecting the active window can silently
-            # clobber the active-pane choice made above whenever the active pane
-            # isn't the window's first pane.
-            return $activePaneId
         }
 
         # Restore first window
@@ -330,8 +372,8 @@ try {
     if ($overwrittenCount -gt 0) {
         $summary += " ($overwrittenCount overwritten)"
     }
-    if ($skipped.Count -gt 0) {
-        $summary = "psmux-resurrect: restored $restoredCount/$totalSessions, skipped $($skipped.Count) (already running)"
+    if ($reusedCount -gt 0) {
+        $summary += " ($reusedCount existing sessions reused)"
     }
     if ($failed.Count -gt 0) {
         $summary += " - failed: $($failed -join ', ')"

--- a/psmux-resurrect/scripts/restore.ps1
+++ b/psmux-resurrect/scripts/restore.ps1
@@ -219,17 +219,28 @@ try {
                 foreach ($line in @($windowLines)) {
                     $parts = "$line".Trim() -split '\|', 2
                     if ($parts.Count -eq 2 -and $parts[1]) {
-                        $existingWindowTargets[$parts[1]] = "${sessionName}:$($parts[0])"
+                        if (-not $existingWindowTargets.ContainsKey($parts[1])) {
+                            $existingWindowTargets[$parts[1]] = @()
+                        }
+                        $existingWindowTargets[$parts[1]] += "${sessionName}:$($parts[0])"
                     }
                 }
 
                 $windowPaneIds = @()
                 $windowActivePaneIds = @()
+                $matchedWindowCounts = @{}
                 $addedWindows = 0
                 foreach ($win in @($session.windows)) {
-                    if ($win.name -and $existingWindowTargets.ContainsKey($win.name)) {
-                        $windowPaneIds += $null
+                    $matchedCount = if ($win.name -and $matchedWindowCounts.ContainsKey($win.name)) {
+                        $matchedWindowCounts[$win.name]
+                    } else {
+                        0
+                    }
+                    if ($win.name -and $existingWindowTargets.ContainsKey($win.name) -and
+                        $matchedCount -lt $existingWindowTargets[$win.name].Count) {
+                        $windowPaneIds += $existingWindowTargets[$win.name][$matchedCount]
                         $windowActivePaneIds += $null
+                        $matchedWindowCounts[$win.name] = $matchedCount + 1
                         continue
                     }
 
@@ -247,7 +258,6 @@ try {
                     $windowActivePaneIds += (Restore-WindowPanes -win $win -initialPaneId $winPaneId)
                     if ($winPaneId) {
                         $addedWindows++
-                        if ($win.name) { $existingWindowTargets[$win.name] = $winPaneId }
                     }
                 }
 
@@ -255,9 +265,6 @@ try {
                 for ($i = 0; $i -lt $savedWindows.Count; $i++) {
                     if ($savedWindows[$i].active -eq $true) {
                         $activeWindowTarget = $windowPaneIds[$i]
-                        if (-not $activeWindowTarget -and $savedWindows[$i].name) {
-                            $activeWindowTarget = $existingWindowTargets[$savedWindows[$i].name]
-                        }
                         if ($activeWindowTarget) {
                             & $PSMUX select-window -t $activeWindowTarget 2>&1 | Out-Null
                             if ($windowActivePaneIds[$i]) {

--- a/tests/test_resurrect_overwrite.ps1
+++ b/tests/test_resurrect_overwrite.ps1
@@ -10,8 +10,8 @@
 # never touches a real dev's ~/.psmux/resurrect.
 #
 # Covers:
-#   - @resurrect-overwrite unset (default off): existing session is left
-#     alone -- no kill-session, no new-session, counted as skipped.
+#   - @resurrect-overwrite unset (default off): existing session is reused,
+#     matching windows are preserved, and missing saved windows are restored.
 #   - @resurrect-overwrite 'on', session exists: kill-session runs BEFORE
 #     new-session (order matters -- recreating before the kill lands would
 #     silently no-op), counted as overwritten.
@@ -43,7 +43,7 @@ $logFile         = Join-Path $stateDir 'calls.log'
 $sessionAliveFlag = Join-Path $stateDir 'session_alive'
 $overwriteOptFile = Join-Path $stateDir 'overwrite_opt'
 
-# Saved environment: one session, one window, one pane. Minimal on purpose --
+# Saved environment: one session, two windows, one pane each. Minimal on purpose --
 # this test is about the exists/overwrite decision, not restore mechanics
 # (those are covered by the E2E and %id-targeting tests elsewhere).
 $saveJson = @'
@@ -53,6 +53,8 @@ $saveJson = @'
   "sessions": [
     { "name": "ow_test_session", "windows": [
       { "index": 0, "name": "main", "active": true, "layout": "abcd,80x24,0,0,1", "zoomed": false, "flags": "",
+        "panes": [ { "index": 0, "directory": "C:/", "active": true, "title": "", "command": "pwsh" } ] },
+      { "index": 1, "name": "nested", "active": false, "layout": "efgh,80x24,0,0,2", "zoomed": false, "flags": "",
         "panes": [ { "index": 0, "directory": "C:/", "active": true, "title": "", "command": "pwsh" } ] }
     ] }
   ]
@@ -78,6 +80,7 @@ switch (`$a[0]) {
     'kill-session' { Remove-Item `$aliveFlag -Force -ErrorAction SilentlyContinue; exit 0 }
     'new-session' { New-Item -ItemType File -Path `$aliveFlag -Force | Out-Null; '%1'; exit 0 }
     'new-window' { '%2'; exit 0 }
+    'list-windows' { '0|main'; exit 0 }
     'split-window' { '%3'; exit 0 }
     'show-options' {
         if (`$a -contains '@resurrect-overwrite') {
@@ -108,14 +111,15 @@ function Reset-Calls {
 function Get-Calls { if (Test-Path $logFile) { Get-Content $logFile } else { @() } }
 
 try {
-    # --- 1. overwrite unset (default off), session exists -> skip, no kill/new-session ---
+    # --- 1. overwrite unset: reuse session and restore its missing nested window ---
     Remove-Item $overwriteOptFile -Force -ErrorAction SilentlyContinue
     New-Item -ItemType File -Path $sessionAliveFlag -Force | Out-Null
     Reset-Calls
     Invoke-Restore
     $calls = Get-Calls
     Check "default (no option set): no kill-session call" (-not ($calls | Where-Object { $_ -like 'kill-session*' }))
-    Check "default (no option set): no new-session call (session left alone)" (-not ($calls | Where-Object { $_ -like 'new-session*' }))
+    Check "default (no option set): no new-session call (session reused)" (-not ($calls | Where-Object { $_ -like 'new-session*' }))
+    Check "default (no option set): missing nested window restored" ($calls | Where-Object { $_ -like 'new-window*-n nested*' }) "calls=$($calls -join ' | ')"
     Check "default (no option set): session still marked alive" (Test-Path $sessionAliveFlag)
 
     # --- 2. overwrite 'on', session exists -> kill-session BEFORE new-session ---

--- a/tests/test_resurrect_overwrite.ps1
+++ b/tests/test_resurrect_overwrite.ps1
@@ -43,7 +43,9 @@ $logFile         = Join-Path $stateDir 'calls.log'
 $sessionAliveFlag = Join-Path $stateDir 'session_alive'
 $overwriteOptFile = Join-Path $stateDir 'overwrite_opt'
 
-# Saved environment: one session, two windows, one pane each. Minimal on purpose --
+# Saved environment: one session with a main window and two windows sharing the
+# nested name. Duplicate names are intentional: reconciliation must match live
+# windows by occurrence, not treat each name as globally unique.
 # this test is about the exists/overwrite decision, not restore mechanics
 # (those are covered by the E2E and %id-targeting tests elsewhere).
 $saveJson = @'
@@ -55,6 +57,8 @@ $saveJson = @'
       { "index": 0, "name": "main", "active": true, "layout": "abcd,80x24,0,0,1", "zoomed": false, "flags": "",
         "panes": [ { "index": 0, "directory": "C:/", "active": true, "title": "", "command": "pwsh" } ] },
       { "index": 1, "name": "nested", "active": false, "layout": "efgh,80x24,0,0,2", "zoomed": false, "flags": "",
+        "panes": [ { "index": 0, "directory": "C:/", "active": true, "title": "", "command": "pwsh" } ] },
+      { "index": 2, "name": "nested", "active": false, "layout": "ijkl,80x24,0,0,3", "zoomed": false, "flags": "",
         "panes": [ { "index": 0, "directory": "C:/", "active": true, "title": "", "command": "pwsh" } ] }
     ] }
   ]
@@ -80,7 +84,7 @@ switch (`$a[0]) {
     'kill-session' { Remove-Item `$aliveFlag -Force -ErrorAction SilentlyContinue; exit 0 }
     'new-session' { New-Item -ItemType File -Path `$aliveFlag -Force | Out-Null; '%1'; exit 0 }
     'new-window' { '%2'; exit 0 }
-    'list-windows' { '0|main'; exit 0 }
+    'list-windows' { '0|main'; '1|nested'; exit 0 }
     'split-window' { '%3'; exit 0 }
     'show-options' {
         if (`$a -contains '@resurrect-overwrite') {
@@ -119,7 +123,9 @@ try {
     $calls = Get-Calls
     Check "default (no option set): no kill-session call" (-not ($calls | Where-Object { $_ -like 'kill-session*' }))
     Check "default (no option set): no new-session call (session reused)" (-not ($calls | Where-Object { $_ -like 'new-session*' }))
-    Check "default (no option set): missing nested window restored" ($calls | Where-Object { $_ -like 'new-window*-n nested*' }) "calls=$($calls -join ' | ')"
+    Check "default (no option set): matching main window preserved" (-not ($calls | Where-Object { $_ -like 'new-window*-n main*' })) "calls=$($calls -join ' | ')"
+    $nestedCreates = @($calls | Where-Object { $_ -like 'new-window*-n nested*' })
+    Check "default (no option set): exactly one missing duplicate nested window restored" ($nestedCreates.Count -eq 1) "calls=$($calls -join ' | ')"
     Check "default (no option set): session still marked alive" (Test-Path $sessionAliveFlag)
 
     # --- 2. overwrite 'on', session exists -> kill-session BEFORE new-session ---


### PR DESCRIPTION
*Coauthored by GitHub Copilot*

**TL;DR:** Reuse existing resurrect sessions while restoring saved windows that are missing, instead of skipping the whole session.

**Key changes**
- Reconcile saved windows by name when a session already exists.
- Preserve matching live windows while fully restoring missing windows and their panes, layouts, titles, processes, and active state.
- Keep `@resurrect-overwrite on` behavior unchanged.
- Add regression coverage for restoring a nested window into an existing session.

<details><summary>Validation</summary>

- `tests\test_resurrect_overwrite.ps1`: 9 passed, 0 failed
- `tests\test_resurrect_guard.ps1`: 7 passed, 0 failed
- `git diff --check`: clean

</details>

# Final Validation Checklist
- [ ] Confirm restoring into an existing session adds missing saved windows without duplicating matching windows.
- [ ] Confirm restored windows retain their saved pane layout and active pane/window state.
- [ ] Confirm `@resurrect-overwrite on` still replaces an existing session.